### PR TITLE
Fix huboard replacements

### DIFF
--- a/github-chrome-fullname/index.js
+++ b/github-chrome-fullname/index.js
@@ -1,6 +1,11 @@
 (function() {
     "use strict";
 
+    var allowedSites = [
+        "github.wdf.sap.corp",
+        "huboard.mo.sap.corp"
+    ];
+
     /*global ReplaceRestricter, UserIdStringReplacer, UserIdReplacer*/
     var restricter = new ReplaceRestricter();
     var userIdStringReplacer = new UserIdStringReplacer("https://github.wdf.sap.corp");
@@ -8,6 +13,15 @@
 
     // Check DOM size every second. After change of DOM elements replace user Ids.
     var lastDomSize;
+
+    var parser = document.createElement('a');
+    parser.href = window.location.href;
+
+    var hostname = parser.hostname;
+    if (allowedSites.indexOf(hostname) === -1) {
+      return;
+    }
+
     window.setInterval(function() {
         if (!restricter.isAllowedUrl(window.location.href)) {
             return;

--- a/github-chrome-fullname/index.js
+++ b/github-chrome-fullname/index.js
@@ -13,11 +13,7 @@
     // Check DOM size every second. After change of DOM elements replace user Ids.
     var lastDomSize;
 
-    var parser = document.createElement('a');
-    parser.href = window.location.href;
-    var hostname = parser.hostname;
-
-    var useFullCheck = (fullCheckSites.indexOf(hostname) !== -1)
+    var useFullCheck = (fullCheckSites.indexOf(window.location.hostname) !== -1)
 
     window.setInterval(function() {
         if (!restricter.isAllowedUrl(window.location.href)) {

--- a/github-chrome-fullname/index.js
+++ b/github-chrome-fullname/index.js
@@ -26,7 +26,7 @@
         if (!restricter.isAllowedUrl(window.location.href)) {
             return;
         }
-        var currentDomSize = document.getElementsByTagName("*").length;
+        var currentDomSize = $('html').html().length;
         if (currentDomSize !== lastDomSize) {
             lastDomSize = currentDomSize;
             userIdReplacer.replaceUserIDs();

--- a/github-chrome-fullname/index.js
+++ b/github-chrome-fullname/index.js
@@ -1,8 +1,7 @@
 (function() {
     "use strict";
 
-    var allowedSites = [
-        "github.wdf.sap.corp",
+    var fullCheckSites = [
         "huboard.mo.sap.corp"
     ];
 
@@ -16,13 +15,9 @@
 
     var parser = document.createElement('a');
     parser.href = window.location.href;
-
     var hostname = parser.hostname;
-    if (allowedSites.indexOf(hostname) === -1) {
-      return;
-    }
 
-    var useFullCheck = (hostname === "huboard.mo.sap.corp")
+    var useFullCheck = (fullCheckSites.indexOf(hostname) !== -1)
 
     window.setInterval(function() {
         if (!restricter.isAllowedUrl(window.location.href)) {

--- a/github-chrome-fullname/index.js
+++ b/github-chrome-fullname/index.js
@@ -22,11 +22,14 @@
       return;
     }
 
+    var useFullCheck = (hostname === "huboard.mo.sap.corp")
+
     window.setInterval(function() {
         if (!restricter.isAllowedUrl(window.location.href)) {
             return;
         }
-        var currentDomSize = $('html').html().length;
+
+        var currentDomSize = useFullCheck ? $('html').html().length : document.getElementsByTagName("*").length;
         if (currentDomSize !== lastDomSize) {
             lastDomSize = currentDomSize;
             userIdReplacer.replaceUserIDs();


### PR DESCRIPTION
The decision whether or no to rerun the expensive replacement operation is currently done using the html tag count method. This creates an issue with huboard because huboard creates some empty html tags and just fills them with content once those html tags are visible.

This PR introduces the method of detecting content change by counting the html size. Counting the html size instead of the dome size is a little bit more expensive, but definitely more reliable (0.02ms with dom counting, 2ms with html size counting).

DOM counting
```js
var t0 = performance.now();
document.getElementsByTagName("*").length;
var t1 = performance.now();
console.log("DOM element counting took " + (t1 - t0) + " milliseconds.")
``` 

HTML size counting
```js
var t0 = performance.now();
$('html').html().length;
var t1 = performance.now();
console.log("HTML size counting took " + (t1 - t0) + " milliseconds.")
```
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cgrail/github-chrome-fullname/pull/4%23discussion_r77368160%22%2C%20%22https%3A//github.com/cgrail/github-chrome-fullname/pull/4%23discussion_r77368395%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%206d3ed2a809f432e06ddd1a4e9026aa2c2b2269b1%20github-chrome-fullname/index.js%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cgrail/github-chrome-fullname/pull/4%23discussion_r77368160%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20don%27t%20need%20to%20do%20this%20check%20here.%20This%20check%20is%20done%20via%20the%20manifest.%5Cr%5Cnhttps%3A//github.com/cgrail/github-chrome-fullname/blob/69c4c1283cdd7b7be306f1a9d8bfc1c984c6a725/github-chrome-fullname/manifest.json%23L14%22%2C%20%22created_at%22%3A%20%222016-09-02T15%3A45%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5702278%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cgrail%22%7D%7D%2C%20%7B%22body%22%3A%20%22https%3A//developer.chrome.com/extensions/content_scripts%23registration%22%2C%20%22created_at%22%3A%20%222016-09-02T15%3A47%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5702278%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cgrail%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20github-chrome-fullname/index.js%3AL1-36%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 6d3ed2a809f432e06ddd1a4e9026aa2c2b2269b1 github-chrome-fullname/index.js 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cgrail/github-chrome-fullname/pull/4#discussion_r77368160'>File: github-chrome-fullname/index.js:L1-36</a></b>
- <a href='https://github.com/cgrail'><img border=0 src='https://avatars.githubusercontent.com/u/5702278?v=3' height=16 width=16'></a> You don't need to do this check here. This check is done via the manifest.
https://github.com/cgrail/github-chrome-fullname/blob/69c4c1283cdd7b7be306f1a9d8bfc1c984c6a725/github-chrome-fullname/manifest.json#L14
- <a href='https://github.com/cgrail'><img border=0 src='https://avatars.githubusercontent.com/u/5702278?v=3' height=16 width=16'></a> https://developer.chrome.com/extensions/content_scripts#registration


<a href='https://www.codereviewhub.com/cgrail/github-chrome-fullname/pull/4?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cgrail/github-chrome-fullname/pull/4?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cgrail/github-chrome-fullname/pull/4'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>