### PR TITLE
[FIX] Do not replace things in GPG key IDs

### DIFF
--- a/src/restrictor.js
+++ b/src/restrictor.js
@@ -72,6 +72,8 @@ export default class Restrictor {
 			.restrict(inside(className("commit-ref")))
 			// Comment for fork: Add more commits by pushing to the
 			.restrict(inside(className("merge-pr-more-commits")))
+			// Signed commit popup: GPG key ID
+			.restrct(inside(className("signed-commit-footer")))
 			// Exclude protip
 			.restrict(inside(className("protip")))
 			// exclude github blobs

--- a/test/restrictor.js
+++ b/test/restrictor.js
@@ -101,4 +101,12 @@ describe("restrictor", () => {
 
 		assert(restrictor2.check(e))
 	})
+
+	it("should not replace things inside a signeds commit GPG key ID", () => {
+		const e = elem`<div class="signed-commit-footer">
+			<span class="d-block">GPG key ID: <span class="text-gray">36095d000007B025</span></span>
+		</div>`
+
+		assert(restrictor.check(e) == false)
+	})
 })


### PR DESCRIPTION
Do not replace usernames within the GPG key ID in the popup for signed commits.