### PR TITLE
Fixed recursive problem if resolved username contains user id

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -52,7 +52,9 @@ export class API3 {
             const searchRegex = new RegExp(`<title>${id} \\((.*)\\)<\\/title>`, "g")
             const match = searchRegex.exec(responseText)
             if (match) {
-                data.name = match[1] || data.name
+                // remove UserID from name, if it contains it.
+                const fixedName = match[1].replace(id,"").trim()
+                data.name = fixedName || data.name
             }
         } catch (e) {
             console.log(e)

--- a/test/api.ts
+++ b/test/api.ts
@@ -18,7 +18,7 @@ describe("api", () => {
 			.resolves(response)
 
 		// Mock the text resolve function to not run into the problem of having an already usedBody
-		sinon.stub(response, "text").resolves("<title>D000000 (Max (Hans) Mustermann)</title>")
+		sinon.stub(response, "text").resolves("<title>D000000 (Max (Hans) Mustermann D000000)</title>")
 	})
 
 	afterEach(async function () {


### PR DESCRIPTION
This PR resolves the issue, that if the Name contains the userid the replacer would recursively replace it.
