### PR TITLE
Added autologin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,36 @@ const replacer = new NodeReplacer(api)
 
 replacer.watch(document.body)
 
+function triggerRelogin(): void {
+    // Check if the user is logged in, if not the body has the css class 'logged-out'
+    if (!document.body.classList.contains('logged-out')) {
+        return
+    }
+
+    // check if an anchor (a-tag) exists which points towards "/login"
+    const hasSignInLinkOnPage = document.querySelector("a[href^='/login']")
+    if (!hasSignInLinkOnPage) {
+        return
+    }
+
+    // If we are on the / or /login page we will directly trigger the login.
+    // If we manually log out, we will land on /dashboard/logged_out
+    // If the auto login fails, we land on /session
+    const loginTriggerPaths = ["/", "/login"]
+    const isPathLoginPath: boolean = loginTriggerPaths.includes(window.location.pathname)
+
+    // check if the document has an element with the classes like the sing in button
+    // This is essential if GitHub is in annoymous mode and allows user to browse without logging in
+    const hasSignInLinkAndClassesMatch: boolean = ["HeaderMenu-link", "no-underline", "mr-3"]
+        .reduce((doClassesMatch: boolean, currentClassName: string): boolean =>
+            doClassesMatch && hasSignInLinkOnPage.classList.contains(currentClassName), true)
+
+    // If we're either on a dedicated login path or if we see the sign in button we force a login
+    if (isPathLoginPath || hasSignInLinkAndClassesMatch) {
+        let encodedRedirectUri = encodeURIComponent(window.location.href)
+        window.location.href = `/login?force_external=true&return_to=${encodedRedirectUri}`
+    }
+}
+
+// Check if the current user is logged in and trigger a relogin if that is not the case
+triggerRelogin()

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
-    "name": "Name instead of UserId for SAP GitHub",
-    "description": "Display full name instead of UserId for SAP GitHub Enterprise instance",
-    "version": "0.5.0",
+    "name": "Name instead of UserId for SAP GitHub & Autologin",
+    "description": "Display full name instead of UserId for SAP GitHub Enterprise instance & perform Autologin via external Identity Provider if logged out",
+    "version": "0.6.0",
     "manifest_version": 2,
     "content_scripts": [{
         "js": [


### PR DESCRIPTION
This PR adds a detection mechanism, which notices if a user is logged out (though the `logged-out` css class on the body) and triggers a relogin. It also handles the case that a user manually sign out to e.g. login to a technical user account. 

Overall this change streamlines the login process and triggers automatic logins when a user isn't logged in. Thus reduces the confusion, if users are not logged in a GitHub server, which allows anonymous access, and see 404 pages for private repositories where they normally have access to.