### PR TITLE
Restrict resolving user id in branch names

### DIFF
--- a/src/restrictor.ts
+++ b/src/restrictor.ts
@@ -82,6 +82,10 @@ export default class Restrictor {
             .restrict(inside(className("copyable-terminal")))
             .restrict(inside(className("js-live-clone-url")))
             .restrict(inside(className("vcard-username")))
+            // Preserves branch names in repository branch dropdown with names that contain user id
+            .restrict(inside(and(tagName("A"), className("select-menu-item"))))
+            // Preserves branch names in branches view of repository at repo/branches
+            .restrict(inside(and(tagName("A"), className("branch-name"))))
             .except(inside(and(tagName("A"), className("author"))))
     }
 


### PR DESCRIPTION
Idea is to preserve the branch names even if it contains user id. Prevents any confusion regarding branch names.

Fixes it at branch dropdown in any repository page and the branches page of any repository present at repo/branches

Fixes #17