### PR TITLE
fixed resolving user name when title is enriched

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -49,7 +49,7 @@ export class API3 {
                 cache: "force-cache"
             })
             const responseText = await response.text()
-            const searchRegex = new RegExp(`<title>${id} \\((.*)\\)<\\/title>`, "g")
+            const searchRegex = new RegExp(`<title>${id} \\((.*)\\)(?: · GitHub)?<\\/title>`, "g")
             const match = searchRegex.exec(responseText)
             if (match) {
                 // remove UserID from name, if it contains it.

--- a/test/api.ts
+++ b/test/api.ts
@@ -8,6 +8,7 @@ import { API3 } from "../src/api"
 describe("api", () => {
 	let fetchStub: any;
 	let oldFetch = (global as any).fetch
+	let responseText = "<title>D000000 (Max (Hans) Mustermann D000000)</title>"
 
 	beforeEach(async function () {
 		fetchStub = sinon.stub(global, "fetch")
@@ -18,7 +19,7 @@ describe("api", () => {
 			.resolves(response)
 
 		// Mock the text resolve function to not run into the problem of having an already usedBody
-		sinon.stub(response, "text").resolves("<title>D000000 (Max (Hans) Mustermann D000000)</title>")
+		sinon.stub(response, "text").resolves(responseText)
 	})
 
 	afterEach(async function () {
@@ -29,6 +30,15 @@ describe("api", () => {
 	
 
 	it("getUser", async function () {
+		const api = new API3()
+		const user = await api.getUser("D000000", "github.wdf.sap.corp")
+		assert(user.getName() === "Max (Hans) Mustermann", "Username must be correct")
+		assert(fetchStub.withArgs("https://github.wdf.sap.corp/D000000").calledOnce)
+	})
+	
+	it("getUser - with enriched title", async function () {
+		responseText = "<title>D000000 (Max (Hans) Mustermann D000000) · GitHub</title>"
+		
 		const api = new API3()
 		const user = await api.getUser("D000000", "github.wdf.sap.corp")
 		assert(user.getName() === "Max (Hans) Mustermann", "Username must be correct")


### PR DESCRIPTION
This PR addresses the issue for some user profiles which can not be resolved because their title is enriched with ` · GitHub`. If required, I can send you some example Ids.

![image](https://user-images.githubusercontent.com/69237656/89407012-57c8f580-d71e-11ea-8105-062523a3b152.png)
