### PR TITLE
Handle HTML encoded usernames

### DIFF
--- a/src/replacer.ts
+++ b/src/replacer.ts
@@ -74,8 +74,15 @@ export class NodeReplacer {
         }
         let userName = user.getName()
         if(userName && userName != "" && node.nodeValue ) {
-            node.nodeValue = node.nodeValue.replace(id, userName)
+            node.nodeValue = node.nodeValue.replace(id, this.decodeHTMLEntities(userName))
         }
+    }
+
+    // Solution from here: https://stackoverflow.com/questions/1147359/how-to-decode-html-entities-using-jquery/1395954#1395954
+    private decodeHTMLEntities(encodedString: string) {
+        const textArea = document.createElement('textarea');
+        textArea.innerHTML = encodedString;
+        return textArea.value;
     }
 }
 

--- a/test/fixtures/github-commits-after.html
+++ b/test/fixtures/github-commits-after.html
@@ -34,7 +34,7 @@
                         <a class="header-nav-link name" href="/d000007" data-ga-click="Header, go to profile, text:username">
                             <img alt="Jesse James" class="avatar" data-user="2082" height="20" src="https://github.corporate/avatars/u/2082?s=40" width="20" />
                             <span class="css-truncate">
-        <span class="css-truncate-target" id="simpleUserId">James Bond</span>
+        <span class="css-truncate-target" id="simpleUserId">James O'Bond</span>
                             </span>
                         </a>
                     </li>
@@ -180,7 +180,7 @@
                     </ul>
                     <h1 itemscope itemtype="http://data-vocabulary.org/Breadcrumb" class="entry-title public">
           <span class="mega-octicon octicon-repo"></span>
-          <span class="author"><a href="/d000007" class="url fn" itemprop="url" rel="author"><span itemprop="title">James Bond</span></a></span><!--
+          <span class="author"><a href="/d000007" class="url fn" itemprop="url" rel="author"><span itemprop="title">James O'Bond</span></a></span><!--
        --><span class="path-divider">/</span><!--
        --><strong><a href="/d000007/testGithubSample" class="js-current-repository" data-pjax="#js-repo-pjax-container">testGithubSample</a></strong>
 
@@ -431,7 +431,7 @@
                                             <a href="/d000007/testGithubSample/commit/fdd5d719541d19796b18ca247e689994871d6f46" class="message" data-pjax="true" title="various fixes">various fixes</a>
                                         </p>
                                         <div class="commit-meta">
-                                            <a href="/d000007/testGithubSample/commits/master?author=d000007" aria-label="View all commits by Jesse James" class="commit-author tooltipped tooltipped-s" rel="author">James Bond</a> authored
+                                            <a href="/d000007/testGithubSample/commits/master?author=d000007" aria-label="View all commits by Jesse James" class="commit-author tooltipped tooltipped-s" rel="author">James O'Bond</a> authored
                                             <time datetime="2015-03-04T08:28:07Z" is="relative-time">Mar 4, 2015</time>
                                         </div>
                                     </div>
@@ -456,7 +456,7 @@
                                             <a href="/d000007/testGithubSample/commit/96b906aab66ff018062486bd41b4a055eca10b95" class="message" data-pjax="true" title="removed sublime-workspace">removed sublime-workspace</a>
                                         </p>
                                         <div class="commit-meta">
-                                            <a href="/d000007/testGithubSample/commits/master?author=d000007" aria-label="View all commits by Jesse James" class="commit-author tooltipped tooltipped-s" rel="author">James Bond</a> authored
+                                            <a href="/d000007/testGithubSample/commits/master?author=d000007" aria-label="View all commits by Jesse James" class="commit-author tooltipped tooltipped-s" rel="author">James O'Bond</a> authored
                                             <time datetime="2015-03-04T08:20:59Z" is="relative-time">Mar 4, 2015</time>
                                         </div>
                                     </div>
@@ -481,7 +481,7 @@
                                             <a href="/d000007/testGithubSample/commit/4973d53e8971a7ac5ac4a17821c0171137130860" class="message" data-pjax="true" title="Delete project.sublime-workspace">Delete project.sublime-workspace</a>
                                         </p>
                                         <div class="commit-meta">
-                                            <a href="/d000007/testGithubSample/commits/master?author=d000007" aria-label="View all commits by Jesse James" class="commit-author tooltipped tooltipped-s" rel="author">James Bond</a> authored
+                                            <a href="/d000007/testGithubSample/commits/master?author=d000007" aria-label="View all commits by Jesse James" class="commit-author tooltipped tooltipped-s" rel="author">James O'Bond</a> authored
                                             <time datetime="2015-03-04T08:18:44Z" is="relative-time">Mar 4, 2015</time>
                                         </div>
                                     </div>
@@ -506,7 +506,7 @@
                                             <a href="/d000007/testGithubSample/commit/5be9e488d240c17f6fe600b3c9dd9add3b9a533b" class="message" data-pjax="true" title="Create README.md">Create README.md</a>
                                         </p>
                                         <div class="commit-meta">
-                                            <a href="/d000007/testGithubSample/commits/master?author=d000007" aria-label="View all commits by Jesse James" class="commit-author tooltipped tooltipped-s" rel="author">James Bond</a> authored
+                                            <a href="/d000007/testGithubSample/commits/master?author=d000007" aria-label="View all commits by Jesse James" class="commit-author tooltipped tooltipped-s" rel="author">James O'Bond</a> authored
                                             <time datetime="2015-03-04T08:15:00Z" is="relative-time">Mar 4, 2015</time>
                                         </div>
                                     </div>
@@ -531,7 +531,7 @@
                                             <a href="/d000007/testGithubSample/commit/0e537858345b5229fb5a889926f62b95afee5627" class="message" data-pjax="true" title="First version of Grunt UI5 Sample Project">First version of Grunt UI5 Sample Project</a>
                                         </p>
                                         <div class="commit-meta">
-                                            <a href="/d000007/testGithubSample/commits/master?author=d000007" aria-label="View all commits by Jesse James" class="commit-author tooltipped tooltipped-s" rel="author">James Bond</a> authored
+                                            <a href="/d000007/testGithubSample/commits/master?author=d000007" aria-label="View all commits by Jesse James" class="commit-author tooltipped tooltipped-s" rel="author">James O'Bond</a> authored
                                             <time datetime="2015-03-04T08:14:01Z" is="relative-time">Mar 4, 2015</time>
                                         </div>
                                     </div>

--- a/test/replacer.ts
+++ b/test/replacer.ts
@@ -37,7 +37,7 @@ describe("replacer", () => {
 	before(async function() {
 		fetchStub = sinon.stub(global, "fetch")
 
-		const response = new Response("<title>d000007 (James Bond)</title>", {
+		const response = new Response("<title>d000007 (James O'Bond)</title>", {
 			status: 200,
 			headers: {
 				"Content-type": "text/html; charset=utf-8"
@@ -49,7 +49,7 @@ describe("replacer", () => {
 			.resolves(response)
 
 			// Mock the text resolve function to not run into the problem of having an already usedBody
-			sinon.stub(response, "text").resolves("<title>d000007 (James Bond)</title>")
+			sinon.stub(response, "text").resolves("<title>d000007 (James O&#39;Bond)</title>")
 	})
 
 	after(() => {


### PR DESCRIPTION
Names with characters like `'` in them are displayed in their HTML encoded form (`&#39;` instead of `'`). For example, `John O’Shea` is displayed as `John O&#39;Shea`.

This PR adds a decoding step in `NodeReplacer` to deal with this.

Code used to decode the string from here: https://stackoverflow.com/questions/1147359/how-to-decode-html-entities-using-jquery/1395954#1395954

Tests pass locally:
![image](https://user-images.githubusercontent.com/212316/143147220-e52c8873-31a5-4f6c-9784-cc3ad51468bd.png)

Tested the extension locally (I'm not attaching screenshots of the browser to keep the names of SAP employees internal).

@cgrail, could you please review and consider merging? Thanks!