### PR TITLE
preventing caching if name is equal to id.

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -48,7 +48,7 @@ export class API3 {
         const userKey = `${id}-${root}`
         if (!this.userMap.has(userKey)) {
             this.userMap.set(userKey, this.getUserFromGitHub(id, root).then((user): User => {
-                if ((user.getName() + '').trim().length) {
+                if ((user.getName() + '').trim().length && user.getName() !== user.getId()) {
                     chrome.storage.local.set({
                         [userKey]: {
                             created: Date.now(),

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Name instead of UserId for SAP GitHub",
     "description": "Display full name instead of UserId for SAP GitHub Enterprise instance & perform auto login via IDP if logged out",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "manifest_version": 2,
     "content_scripts": [
         {


### PR DESCRIPTION
Some times we are getting id as value instead of name, preventing caching in such cases.